### PR TITLE
Added a workflow that will produce release on every main branch merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Publish
+        run: dotnet publish --configuration Release --output ./publish
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          git fetch --tags
+          latest_tag=$(git tag --sort=-v:refname | head -n 1)
+          if [[ -z "$latest_tag" ]]; then
+            echo "tag=1.0.0" >> $GITHUB_OUTPUT
+          else
+            IFS='.' read -r major minor patch <<< "$latest_tag"
+            patch=$((patch+1))
+            echo "tag=$major.$minor.$patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release Tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = process.env['TAG'] || '${{ steps.get_tag.outputs.tag }}';
+            const sha = process.env['GITHUB_SHA'] || '${{ github.sha }}';
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tag}`,
+              sha: sha
+            });
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_tag.outputs.tag }}
+          name: Release ${{ steps.get_tag.outputs.tag }}
+          files: ./publish/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to build, version, and release the .NET project on every merge to main.

CI:
- Trigger the workflow on pushes to the main branch
- Restore dependencies, build, and publish the .NET project in Release configuration
- Automatically fetch and increment the latest tag (or default to 1.0.0) for semantic versioning
- Create a Git tag and GitHub Release with the published artifacts