### PR TITLE
Add serilog for logging logs using Singleton pattern #6

### DIFF
--- a/ChatBackend.csproj
+++ b/ChatBackend.csproj
@@ -20,6 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,12 @@ using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var seqUrl = builder.Configuration["LoggingPaths:SeqServerUrl"]
+             ?? "http://localhost:5341";
+
+var logFilePath = builder.Configuration["LoggingPaths:FilePath"]
+                  ?? "logs/chatbackend-.txt";
+
 var env = builder.Environment;
 
 // Configure Serilog
@@ -23,8 +29,8 @@ var loggerConfig = new LoggerConfiguration()
     .Enrich.WithEnvironmentName()    
     .Enrich.WithEnvironmentUserName() 
     .WriteTo.Console()
-    .WriteTo.File("logs/chatbackend-.txt", rollingInterval: RollingInterval.Day)
-    .WriteTo.Seq("http://localhost:5341")
+    .WriteTo.File(logFilePath, rollingInterval: RollingInterval.Day)
+    .WriteTo.Seq(seqUrl)
     .MinimumLevel.Debug();
 
 if (env.IsDevelopment())

--- a/Services/AppLoggerService.cs
+++ b/Services/AppLoggerService.cs
@@ -1,0 +1,32 @@
+﻿using Serilog;
+using Serilog.Context;
+using ILogger = Serilog.ILogger;
+
+namespace ChatBackend.Services
+{
+    public class AppLoggerService : IAppLogger
+    {
+        private readonly ILogger _logger;
+        public AppLoggerService()
+        {
+            _logger = Log.Logger.ForContext("App", "ChatBackendAPI");
+        }
+
+        public void Info(string message, object? context = null) => PushContext(context, () => _logger.Information(message));
+        public void Warn(string message, object? context = null) => PushContext(context, () => _logger.Warning(message));
+        public void Error(string message, Exception? ex = null, object? context = null) => PushContext(context, () => _logger.Error(ex, message));
+        public void Debug(string message, object? context = null) => PushContext(context, () => _logger.Debug(message));
+
+        public void LogBusinessEvent(string message, object? context = null) => PushContext(context, () => _logger.Information("[BusinessEvent] " + message));
+        public void TrackExecutionTime(string operation, TimeSpan duration, object? context = null) => PushContext(context, () => _logger.Information("{Operation} took {Duration}ms", operation, duration.TotalMilliseconds));
+
+        private void PushContext(object? context, Action logAction)
+        {
+            using (LogContext.PushProperty("Context", context, destructureObjects: true))
+            {
+                logAction();
+            }
+        }
+
+    }
+}

--- a/Services/IServices.cs
+++ b/Services/IServices.cs
@@ -39,4 +39,16 @@ namespace ChatBackend.Services
         Task<bool> DeleteFileAsync(string fileUrl);
         Task<string> GetPresignedUrlAsync(string fileKey, TimeSpan expiration);
     }
+
+
+
+    public interface IAppLogger
+    {
+        void Info(string message, object? context = null);
+        void Warn(string message, object? context = null);
+        void Error(string message, Exception? ex = null, object? context = null);
+        void Debug(string message, object? context = null);
+        void LogBusinessEvent(string message, object? context = null);
+        void TrackExecutionTime(string operation, TimeSpan duration, object? context = null);
+    }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -22,5 +22,9 @@
       "Microsoft.AspNetCore.Http.Connections": "Debug"
     }
   },
+  "LoggingPaths": {
+    "SeqServerUrl": "http://localhost:5341",
+    "FilePath": "logs/chatbackend-.txt"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Added a new Logging Service (AppLogger) that wraps the global Serilog logger. This service logs messages to both file and Seq, enabling better tracking and observability.

Introduced new NuGet packages for Serilog enrichment (thread info, machine info, environment).
AppLogger is implemented as a singleton, providing a centralized and consistent logger instance across the application.
Provides a custom wrapper for logging business-specific events while internally using Serilog for structured logging.
Configured logs to be written to both a rolling file and a Seq server.

Impact:
Centralizes logging logic for controllers, services, background jobs, and SignalR hubs.
Ensures consistent, extensible, and maintainable logging throughout the application.

This PR resolves issue #6 